### PR TITLE
Voeg preview link comment toe op pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,3 +65,19 @@ jobs:
          git config user.email "api@logius.nl"
          git diff-index --quiet HEAD || git commit -m "new preview build"
          git push
+      - name: Zoek preview link
+        uses: peter-evans/find-comment@v3
+        id: findcomment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Preview link voor pull request
+
+      - name: Post preview link
+        if: steps.findcomment.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            [Preview link voor pull request](https://logius-standaarden.github.io/Publicatie-Preview/${{ github.event.repository.name }}/${{ github.head_ref }})
+


### PR DESCRIPTION
Hiermee posten we automatisch een link naar de preview
(nadat hij is gepusht) op de pull request. De action werkt
door eerst te zoeken naar een bestaand comment. Als er
geen comment te vinden is (commit-id is een empty string)
dan post de bot een markdown link naar de preview.