### PR TITLE
Gebruik GitHub actions om GitHub Pages te publiceren

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'Logius-standaarden' && github.head_ref != 'develop' }}
     env:
       ORGANISATION_URL: https://logius-standaarden.github.io
+      PREVIEW_REPOSITORY_NAME: Publicatie-Preview
       FULL_REPOSITORY_NAME: ${{ github.event.repository.name }}/${{ github.head_ref }}
     steps:
       - uses: actions/checkout@v4
@@ -83,10 +84,10 @@ jobs:
          rm -f *.md *.pdf *.js snapshot.html
          mkdir ~/content
          mv ./* ~/content
-         git clone https://user:${{ secrets.BEHEER }}@github.com/Logius-standaarden/Publicatie-Preview.git
+         git clone https://user:${{ secrets.BEHEER }}@github.com/Logius-standaarden/$PREVIEW_REPOSITORY_NAME.git
       - name: Commit preview
         run: |
-         cd Publicatie-Preview
+         cd $PREVIEW_REPOSITORY_NAME
          rm -f -r $FULL_REPOSITORY_NAME
          mkdir -p $FULL_REPOSITORY_NAME
          mv ~/content/* $FULL_REPOSITORY_NAME
@@ -107,10 +108,10 @@ jobs:
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
-          PREVIEW_LINK_URL: $ORGANISATION_URL/Publicatie-Preview/${{ env.FULL_REPOSITORY_NAME }}
+          PREVIEW_LINK_URL: ${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ env.FULL_REPOSITORY_NAME }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})
-            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=$ORGANISATION_URL/${{ github.event.repository.name }}&doc2=${{ env.PREVIEW_LINK_URL }})
+            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}&doc2=${{ env.PREVIEW_LINK_URL }})
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,9 @@ jobs:
         uses: actions/upload-pages-artifact@v3
   deploy-develop:
     name: Deploy develop
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages
       url: ${{ steps.upload_pages_artifact.outputs.page_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,11 +54,11 @@ jobs:
           rm -f *.md *.pdf *.js snapshot.html
           mkdir ~/content
           mv ./* ~/content
+          mkdir _site
+          mv ~/content/* _site
       - name: Upload static files as artifact
         id: upload_pages_artifact
         uses: actions/upload-pages-artifact@v3
-        with:
-          path: ~/content
   deploy-develop:
     name: Deploy develop
     environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden'}}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -38,7 +38,7 @@ jobs:
   upload_develop_artifacts:
     name: Upload develop artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref == 'develop' }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
     name: Upload develop artifacts
     runs-on: ubuntu-latest
     # if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.number == 166 }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.number == 166 }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -47,6 +47,10 @@ jobs:
         with:
           path: ~/static
           key: ${{ github.run_id }}
+      - name: Rename index
+        run: |
+          cd ~/static
+          mv snapshot.html index.html
       - name: Upload static files as artifact
         id: upload_pages_artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,10 +107,10 @@ jobs:
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
-          PREVIEW_LINK_URL: $ORGANISATION_URL/Publicatie-Preview/$FULL_REPOSITORY_NAME
+          PREVIEW_LINK_URL: $ORGANISATION_URL/Publicatie-Preview/${{ vars.FULL_REPOSITORY_NAME }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Preview link voor pull request]($PREVIEW_LINK_URL)
-            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=$ORGANISATION_URL/${{ github.event.repository.name }}&doc2=$PREVIEW_LINK_URL)
+            [Preview link voor pull request](${{ vars.PREVIEW_LINK_URL }})
+            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=$ORGANISATION_URL/${{ github.event.repository.name }}&doc2=${{ vars.PREVIEW_LINK_URL }})
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,8 @@ jobs:
   upload_develop_artifacts:
     name: Upload develop artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
+    # if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.number == 166 }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
     env:
       ORGANISATION_URL: https://logius-standaarden.github.io
       PREVIEW_REPOSITORY_NAME: Publicatie-Preview
-      FULL_REPOSITORY_NAME: ${{ github.event.repository.name }}/${{ github.head_ref }}
+      REPOSITORY_NAME_AND_BRANCH: ${{ github.event.repository.name }}/${{ github.head_ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -88,9 +88,9 @@ jobs:
       - name: Commit preview
         run: |
          cd $PREVIEW_REPOSITORY_NAME
-         rm -f -r $FULL_REPOSITORY_NAME
-         mkdir -p $FULL_REPOSITORY_NAME
-         mv ~/content/* $FULL_REPOSITORY_NAME
+         rm -f -r $REPOSITORY_NAME_AND_BRANCH
+         mkdir -p $REPOSITORY_NAME_AND_BRANCH
+         mv ~/content/* $REPOSITORY_NAME_AND_BRANCH
          git add -A
          git config user.name "GitHub Action"
          git config user.email "api@logius.nl"
@@ -108,7 +108,7 @@ jobs:
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
-          PREVIEW_LINK_URL: ${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ env.FULL_REPOSITORY_NAME }}
+          PREVIEW_LINK_URL: ${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ env.REPOSITORY_NAME_AND_BRANCH }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,13 +49,16 @@ jobs:
           key: ${{ github.run_id }}
       - name: Rename index
         run: |
-          cd ~/static
-          mv snapshot.html index.html
+          rm index.html
+          mv ~/static/snapshot.html index.html
+          rm -f *.md *.pdf *.js snapshot.html
+          mkdir ~/content
+          mv ./* ~/content
       - name: Upload static files as artifact
         id: upload_pages_artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ~/static
+          path: ~/content
   deploy-develop:
     name: Deploy develop
     environment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,40 @@ jobs:
          git config user.email "api@logius.nl"
          git diff-index --quiet HEAD || git commit -m "Release: ${{ github.event.repository.name }}"
          git push
+  upload_develop_artifacts:
+    name: Upload develop artifacts
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Recover HTML
+        uses: actions/cache@v4
+        with:
+          path: ~/static
+          key: ${{ github.run_id }}
+      - name: Upload static files as artifact
+        id: upload_pages_artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ~/static
+  deploy-develop:
+    name: Deploy develop
+    environment:
+      name: github-pages
+      url: ${{ steps.upload_pages_artifact.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: upload_develop_artifacts
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
   preview:
     name: Preview
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'Logius-standaarden' && github.head_ref != 'develop' }}
+    env:
+      ORGANISATION_URL: https://logius-standaarden.github.io
+      FULL_REPOSITORY_NAME: ${{ github.event.repository.name }}/${{ github.head_ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -57,9 +87,9 @@ jobs:
       - name: Commit preview
         run: |
          cd Publicatie-Preview
-         rm -f -r ${{ github.event.repository.name }}/${{ github.head_ref }}
-         mkdir -p ${{ github.event.repository.name }}/${{ github.head_ref }}
-         mv ~/content/* ${{ github.event.repository.name }}/${{ github.head_ref }}
+         rm -f -r $FULL_REPOSITORY_NAME
+         mkdir -p $FULL_REPOSITORY_NAME
+         mv ~/content/* $FULL_REPOSITORY_NAME
          git add -A
          git config user.name "GitHub Action"
          git config user.email "api@logius.nl"
@@ -76,8 +106,11 @@ jobs:
       - name: Post preview link
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
+        env:
+          PREVIEW_LINK_URL: $ORGANISATION_URL/Publicatie-Preview/$FULL_REPOSITORY_NAME
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Preview link voor pull request](https://logius-standaarden.github.io/Publicatie-Preview/${{ github.event.repository.name }}/${{ github.head_ref }})
+            [Preview link voor pull request]($PREVIEW_LINK_URL)
+            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=$ORGANISATION_URL/${{ github.event.repository.name }}&doc2=$PREVIEW_LINK_URL)
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,7 @@ jobs:
   upload_develop_artifacts:
     name: Upload develop artifacts
     runs-on: ubuntu-latest
-    # if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.number == 166 }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.head_ref == 'develop'}}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -62,8 +61,8 @@ jobs:
   deploy-develop:
     name: Deploy develop
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.upload_pages_artifact.outputs.page_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,10 +107,10 @@ jobs:
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
-          PREVIEW_LINK_URL: $ORGANISATION_URL/Publicatie-Preview/${{ vars.FULL_REPOSITORY_NAME }}
+          PREVIEW_LINK_URL: $ORGANISATION_URL/Publicatie-Preview/${{ env.FULL_REPOSITORY_NAME }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Preview link voor pull request](${{ vars.PREVIEW_LINK_URL }})
-            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=$ORGANISATION_URL/${{ github.event.repository.name }}&doc2=${{ vars.PREVIEW_LINK_URL }})
+            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})
+            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=$ORGANISATION_URL/${{ github.event.repository.name }}&doc2=${{ env.PREVIEW_LINK_URL }})
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref == 'main' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -38,7 +38,7 @@ jobs:
   upload_develop_artifacts:
     name: Upload develop artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref == 'develop' }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref_name == 'develop' }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML


### PR DESCRIPTION
Deze methode wordt nu aanbevolen en zorgt ervoor dat we de gebouwde artifacts
als `develop` werkversie kunnen plaatsen. Hiermee zorgen we ervoor dat de W3C
diff correct werkt, omdat er nu gegenereerde documenten worden vergeleken
in plaats van een dynamische versus status pagina.