### PR TITLE
Implementeer automatisch redirects voor versies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/static
-          key: ${{ github.run_id }}      
+          key: ${{ github.run_id }}
       - name: Gather files
-        run: |         
-         rm -f *.md *.html
-         mv ~/static/* ./
-         mv snapshot.html index.html
-         mkdir content
-         shopt -s extglob
-         mv !(content) content
+        run: |
+         wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/gather-files.sh
+         bash gather-files.sh
          git clone https://user:${{ secrets.BEHEER }}@github.com/Logius-standaarden/publicatie.git
       - name: Commit release
         run: |
@@ -48,12 +44,8 @@ jobs:
           key: ${{ github.run_id }}
       - name: Rename index
         run: |
-          rm index.html
-          mv ~/static/* ./
-          mv snapshot.html index.html
-          rm -f *.md *.js
-          mkdir ~/content
-          mv ./* ~/content
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/gather-files.sh
+          bash gather-files.sh
           mkdir _site
           mv ~/content/* _site
       - name: Upload static files as artifact
@@ -87,14 +79,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/static
-          key: ${{ github.run_id }}      
+          key: ${{ github.run_id }}
       - name: Gather files
         run: |
-         rm index.html
-         mv ~/static/snapshot.html index.html
-         rm -f *.md *.pdf *.js snapshot.html
-         mkdir ~/content
-         mv ./* ~/content
+         wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/gather-files.sh
+         bash gather-files.sh
          git clone https://user:${{ secrets.BEHEER }}@github.com/Logius-standaarden/$PREVIEW_REPOSITORY_NAME.git
       - name: Commit preview
         run: |

--- a/scripts/gather-files.sh
+++ b/scripts/gather-files.sh
@@ -1,0 +1,6 @@
+rm -rf ~/content
+mkdir ~/content
+cp ~/static/* ~/content/
+mv ~/content/snapshot.html ~/content/index.html
+mkdir ~/content/media/
+cp ./media/* ~/content/media/

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,6 +1,11 @@
 import os
+import re
 import shutil
+from pathlib import Path
 
+HOME_DIRECTORY = Path.home()
+CURRENT_WORKING_DIRECTORY = Path.cwd()
+CONTENT_DIRECTORY = HOME_DIRECTORY / "content"
 
 def getValue(var, line):
     comment = line.find("//")
@@ -13,52 +18,62 @@ def getValue(var, line):
     return val
 
 
-content = "content"
-config = f"{content}/js/config.js"
-f = open(config, "r", encoding="utf-8")
+config = f"js/config.js"
+with open(config, "r", encoding="utf-8") as f:
+    pubDomain = ""
+    shortName = ""
+    publishVersion = ""
 
-pubDomain = ""
-shortName = ""
-publishVersion = ""
+    for line in f:
+        if "pubDomain" in line:
+            val = getValue("pubDomain", line)
+            if val:
+                pubDomain = val
+        elif "shortName" in line:
+            val = getValue("shortName", line)
+            if val:
+                shortName = val
+        elif "publishVersion" in line:
+            val = getValue("publishVersion", line)
+            if val:
+                publishVersion = val
 
-for line in f:
-    if "pubDomain" in line:
-        val = getValue("pubDomain", line)
-        if val:
-            pubDomain = val
-    elif "shortName" in line:
-        val = getValue("shortName", line)
-        if val:
-            shortName = val
-    elif "publishVersion" in line:
-        val = getValue("publishVersion", line)
-        if val:
-            publishVersion = val
-f.close()
-os.remove(config)
+SPECIFICATION_FOLDER = CURRENT_WORKING_DIRECTORY / "publicatie" / pubDomain / shortName
 
-if len(pubDomain) * len(shortName) > 0:
+def create_redirect_for_version(publishVersion):
+    with open(f'{SPECIFICATION_FOLDER}/index.html', 'w') as root_index_file:
+        root_index_file.write(f"""<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to v{publishVersion}</title>
+<meta http-equiv="refresh" content="0; URL=./{publishVersion}">
+<link rel="canonical" href="./{publishVersion}">
+""")
+
+    current_version = publishVersion
+
+    while current_version.find(".") > 0:
+        version_without_last_number = ".".join(re.split("\.", current_version)[:-1])
+        version_less_directory = SPECIFICATION_FOLDER / version_without_last_number
+        os.makedirs(version_less_directory, exist_ok=True)
+
+        with open(version_less_directory / 'index.html', 'w') as version_redirect_file:
+            version_redirect_file.write(f"""<!DOCTYPE html>
+    <meta charset="utf-8">
+    <title>Redirecting to v{publishVersion}</title>
+    <meta http-equiv="refresh" content="0; URL=../{publishVersion}">
+    <link rel="canonical" href="../{publishVersion}">
+    """)
+
+        current_version = version_without_last_number
+
+
+if len(pubDomain) * len(shortName) * len(publishVersion) > 0:
     try:
-        if len(publishVersion) > 0:
-            shutil.copytree(content, f"{content}/{publishVersion}")
-        path = f"publicatie/{pubDomain}/{shortName}/"
-        if not os.path.exists(path):
-            os.makedirs(path)
-        for fn in os.listdir(path):
-            # https://stackoverflow.com/a/185941
-            file_path = os.path.join(path, fn)
-            try:
-                print("file_path: " + file_path)
-                if os.path.isdir(file_path):
-                    files = os.listdir(file_path)
-                    if "index.html" in files and fn != publishVersion:
-                        shutil.copytree(file_path, f"{content}/{fn}")
-            except Exception as e:
-                print(e)
-        shutil.rmtree(path)
-        print("Cleared dir: " + path)
-        shutil.copytree(content, path)
-        print("Created dir: " + path)
+        published_path = SPECIFICATION_FOLDER / publishVersion
+        if os.path.exists(published_path):
+            shutil.rmtree(published_path)
+        shutil.copytree(CONTENT_DIRECTORY, published_path)
+        create_redirect_for_version(publishVersion)
     except Exception as e:
         print(e)
 else:


### PR DESCRIPTION
Hiermee creeren we automatisch redirects die het laatste getal
er afhalen. Dus 2.0 redirect naar 2.0.2 en 1 redirect naar 1.8.

Tevens publiceren we documenten nu niet meer dubbel, maar
redirecten we naar de specifieke versie.

Fixes Logius-standaarden/Automatisering#20