### PR TITLE
Limiteer connections met muffet

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,6 +18,7 @@ jobs:
             --header 'user-agent:Curl'
             --ignore-fragments
             --json
+            --max-connections 32
             --accepted-status-codes 200..300,301,403,429
             --buffer-size 8192
             https://gitdocumentatie.logius.nl/publicatie/scripts/paths.html


### PR DESCRIPTION
Om timeouts te voorkomen kunnen we de connections limiteren en zo hopelijk de hoeveelheid broken links te reduceren.