### PR TITLE
Skip updaten labels van gearchiveerde repositories

### DIFF
--- a/scripts/labels.py
+++ b/scripts/labels.py
@@ -9,6 +9,8 @@ labels = org.get_repo('Automatisering').get_labels()
 for repo in repos:
     if repo.name == 'Automatisering':
         continue
+    if repo.archived:
+        continue
     print('* Checking ' + repo.name)
     try:
         repo_labels = repo.get_labels()


### PR DESCRIPTION
Voor gearchiveerde repositories wordt er nu een 403 gegeven als de labels worden geupdate:

```
Request POST /repos/Logius-standaarden/docs-stage-resultaten/labels failed with 403: Forbidden
```

Daarom moeten we deze repositories skippen, omdat alle configuratie van de repository vast staat.