### PR TITLE
Ignore text fragment URLS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
           key: ${{ github.run_id }}
       - run: mv ~/static/snapshot.html snapshot.html
       - run: npm install -g pa11y
-      - run: pa11y snapshot.html --ignore WCAG2AA.Principle4.Guideline4_1.4_1_1.F77
+      - run: pa11y snapshot.html --ignore WCAG2AA.Principle4.Guideline4_1.4_1_1.F77 --ignore WCAG2AA.Principle2.Guideline2_4.2_4_1.G1,G123,G124.NoSuchID
 
   links:
     name: Links


### PR DESCRIPTION
Is op dit moment niet gesupport door pa11y:
https://github.com/pa11y/pa11y/issues/716 en https://github.com/dequelabs/axe-core/issues/4733

Omdat we dit toevoegen aan de ADR moeten
we ze voorlopig ignoren.