### PR TITLE
Zet linter warnings expliciet aan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Static HTML
         run: |
-          npx respec --localhost --src index.html --out ~/static/snapshot.html
+          npx respec --localhost --src index.html --out ~/static/snapshot.html --haltonwarn
       - name: Check config
         id: config
         if: ${{ github.event_name == 'push'}}


### PR DESCRIPTION
De linter draaide wel al, maar het faalde niet de build. Nu faalt hij
de build als er warnings (of errors) worden gegenereerd.