### PR TITLE
Update accessibility checker naar axe

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,24 @@ jobs:
       - run: mv ~/static/snapshot.html snapshot.html
       - run: npm install @axe-core/cli browser-driver-manager -g
       - run: npx browser-driver-manager install chrome
-      - run: axe snapshot.html --exit
+      - name: Serve Files
+        uses: Eun/http-server-action@v1
+        with:
+          content-types: |
+            {
+              "css": "text/css",
+              "html": "text/html",
+              "ico": "image/x-icon",
+              "jpeg": "image/jpeg",
+              "jpg": "image/jpeg",
+              "js": "text/javascript",
+              "json": "application/json",
+              "png": "image/png",
+              "svg": "image/svg+xml",
+              "txt": "text/plain",
+              "xml": "text/xml"
+            }
+      - run: axe http://localhost:8080/snapshot.html --exit
 
   links:
     name: Links

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
           key: ${{ github.run_id }}
       - run: mv ~/static/snapshot.html snapshot.html
       - run: npm install -g pa11y
-      - run: pa11y snapshot.html --ignore WCAG2AA.Principle4.Guideline4_1.4_1_1.F77
+      - run: pa11y --runner axe snapshot.html --ignore WCAG2AA.Principle4.Guideline4_1.4_1_1.F77
 
   links:
     name: Links

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,9 @@ jobs:
           path: ~/static
           key: ${{ github.run_id }}
       - run: mv ~/static/snapshot.html snapshot.html
-      - run: npm install -g pa11y
-      - run: pa11y --runner axe snapshot.html --ignore WCAG2AA.Principle4.Guideline4_1.4_1_1.F77
+      - run: npm install @axe-core/cli browser-driver-manager -g
+      - run: npx browser-driver-manager install chrome
+      - run: axe snapshot.html --exit
 
   links:
     name: Links

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
               "txt": "text/plain",
               "xml": "text/xml"
             }
-      - run: axe http://localhost:8080/snapshot.html --exit
+      - run: axe http://localhost:8080/snapshot.html --exit --tags wcag2aa
 
   links:
     name: Links


### PR DESCRIPTION
Pa11y is oud en werkt niet meer naar behoren. We moeten `axe` gebruiken
om alle moderne formaten van HTML aan te kunnen.