### PR TITLE
Stop met checken van NEN norm

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,5 +73,6 @@ jobs:
           --exclude 'upwork.com'
           --exclude 'sitearchief.nl'
           --exclude 'opengis.net'
+          --exclude 'https://www.nen.nl/nen-7513-2024-nl-329182'
           --header 'user-agent:Curl' --ignore-fragments --one-page-only http://localhost:8080/snapshot.html
           --buffer-size 8192


### PR DESCRIPTION
Deze gebruiken we als referentie in de inleiding van Logboek Dataverwerkingen, maar is te groot om te downloaden. Daarom kunnen we het beter negeren in plaats van de buffer grootte voor alle links te vergroten en mogelijk teveel binnen te trekken.