### PR TITLE
Publiceer ook PDF's in werkversie

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           rm index.html
           mv ~/static/snapshot.html index.html
-          rm -f *.md *.pdf *.js snapshot.html
+          rm -f *.md *.js snapshot.html
           mkdir ~/content
           mv ./* ~/content
           mkdir _site


### PR DESCRIPTION
Het Juridisch beleidskader heeft een PDF
(https://logius-standaarden.github.io/logboek-dataverwerkingen_Juridisch-beleidskader/Juridisch_Beleidskader-Logboek_Dataverwerking.pdf), maar die publiceren we niet omdat we in de develop artifacts de PDF bestandjes opruimen.