### PR TITLE
Check links periodiek voor gepubliceerde versie

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,5 +80,5 @@ jobs:
         run: brew install muffet      
       - name: Check links
         run: |
-          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/run-muffet.sh
           bash run-muffet.sh http://localhost:8080/snapshot.html

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,14 +78,7 @@ jobs:
       - run: echo '/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin' >> $GITHUB_PATH
       - name: Install muffet
         run: brew install muffet      
-      - name: Check links      
-        run: >
-          muffet
-          --exclude '8080\/\S*\.pdf'
-          --exclude '^https:\/\/gitdocumentatie.*(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
-          --exclude 'upwork.com'
-          --exclude 'sitearchief.nl'
-          --exclude 'opengis.net'
-          --exclude 'https://www.nen.nl/nen-7513-2024-nl-329182'
-          --header 'user-agent:Curl' --ignore-fragments --one-page-only http://localhost:8080/snapshot.html
-          --buffer-size 8192
+      - name: Check links
+        run: |
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
+          bash run-muffet.sh http://localhost:8080/snapshot.html

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,8 +22,7 @@ jobs:
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.js
           PUBLISHED_DOMAIN=$(node compute-published-url.js)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/run-muffet.sh
-          # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN || true
-          bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/ > muffet.json || true
+          bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN > muffet.json || true
       - name: Collect broken links
         id: collect-broken-links
         run: |

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,8 +22,8 @@ jobs:
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/compute-published-url.js
           PUBLISHED_DOMAIN=$(node compute-published-url.js)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
-          # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN
-          bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/
+          # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN || true
+          bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/ || true
       - name: Collect broken links
         run: |
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/muffet-json.py

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: Install muffet
         run: brew install muffet
       - name: Check published documents

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -23,7 +23,7 @@ jobs:
           PUBLISHED_DOMAIN=$(node compute-published-url.js)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
           # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN || true
-          bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/ || true
+          bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/ > muffet.json || true
       - name: Collect broken links
         id: collect-broken-links
         run: |

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/muffet-json.py
           python muffet-json.py
-          if [ -f "muffet.json" ]; then
+          if [ -f "links.md" ]; then
+            echo "links.md bestaat"
             echo "has-errors=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Send email

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,7 +22,8 @@ jobs:
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/compute-published-url.js
           PUBLISHED_DOMAIN=$(node compute-published-url.js)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
-          bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN
+          # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN
+          bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/
       - name: Collect broken links
         run: |
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/muffet-json.py

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -25,11 +25,11 @@ jobs:
           # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN || true
           bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/ || true
       - name: Collect broken links
+        id: collect-broken-links
         run: |
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/muffet-json.py
           python muffet-json.py
           if [ -f "links.md" ]; then
-            echo "links.md bestaat"
             echo "has-errors=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Send email

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,15 +1,15 @@
 name: Check published links
 on:
   workflow_dispatch:
-  schedule:
+  # Uncomment waar je de workflow gebruikt
+  # schedule:
     # Run on Mondays at 5:45 UTC
-    - cron: '45 5 * * 1'
+    # - cron: '45 5 * * 1'
 
 jobs:
   link-checker:
     name: Check published links
     runs-on: ubuntu-22.04
-    if: ${{ github.repository_owner == 'Logius-standaarden' && github.repository != 'Logius-standaarden/Automatisering' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install muffet

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,6 +10,7 @@ jobs:
   link-checker:
     name: Check published links
     runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'Logius-standaarden' && github.repository != 'Logius-standaarden/ReSpec-template' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Homebrew
@@ -22,12 +23,15 @@ jobs:
           PUBLISHED_DOMAIN=$(node compute-published-url.js)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
           bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN
-        continue-on-error: true
       - name: Collect broken links
         run: |
-          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/muffet-json.py
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/muffet-json.py
           python muffet-json.py
+          if [ -f "muffet.json" ]; then
+            echo "has-errors=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Send email
+        if: steps.collect-broken-links.outputs.has-errors != ''
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -19,15 +19,15 @@ jobs:
         run: brew install muffet
       - name: Check published documents
         run: |
-          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/compute-published-url.js
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.js
           PUBLISHED_DOMAIN=$(node compute-published-url.js)
-          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/run-muffet.sh
           # bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN || true
           bash run-muffet.sh https://logius-standaarden.github.io/publicatie/testing/test/0.0.1/ > muffet.json || true
       - name: Collect broken links
         id: collect-broken-links
         run: |
-          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/muffet-json.py
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/muffet-json.py
           python muffet-json.py
           if [ -f "links.md" ]; then
             echo "has-errors=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Check published documents
         run: |
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/compute-published-url.js
-          PUBLISHED_URL=$(node compute-published-url.js)
+          PUBLISHED_DOMAIN=$(node compute-published-url.js)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
-          bash run-muffet.sh $PUBLISHED_URL
+          bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN
         continue-on-error: true
       - name: Collect broken links
         run: |

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,6 +1,6 @@
 name: Check published links
 on:
-  workflow_dispatch:
+  workflow_call:
   # Uncomment waar je de workflow gebruikt
   # schedule:
     # Run on Mondays at 5:45 UTC

--- a/.github/workflows/schedules/link-checker.yml
+++ b/.github/workflows/schedules/link-checker.yml
@@ -1,0 +1,41 @@
+name: Check published links
+on:
+  workflow_dispatch:
+  schedule:
+    # Run on Mondays at 5:45 UTC
+    - cron: '45 5 * * 1'
+
+jobs:
+  link-checker:
+    name: Check published links
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'Logius-standaarden' && github.repository != 'Logius-standaarden/Automatisering' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install muffet
+        run: brew install muffet
+      - name: Check published documents
+        run: |
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/compute-published-url.js
+          PUBLISHED_URL=$(node compute-published-url.js)
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/pr-timvdlippe-nieuwe-link-checker/scripts/run-muffet.sh
+          bash run-muffet.sh $PUBLISHED_URL
+        continue-on-error: true
+      - name: Collect broken links
+        run: |
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/muffet-json.py
+          python muffet-json.py
+      - name: Send email
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          subject: Broken links on gitdocumentatie voor ${{ github.repository }}
+          to: ${{secrets.MAIL_RECIPIENTS}}
+          from: Standaarden Bot
+          html_body: file://links.md
+          ignore_cert: true
+          convert_markdown: true

--- a/scripts/compute-published-url.js
+++ b/scripts/compute-published-url.js
@@ -1,0 +1,4 @@
+require("./js/config.js");
+const {pubDomain, shortName} = globalThis.respecConfig;
+
+console.log(`${pubDomain}/${shortName}`);

--- a/scripts/compute-published-url.js
+++ b/scripts/compute-published-url.js
@@ -1,6 +1,4 @@
 require("./js/config.js");
 const {pubDomain, shortName} = globalThis.respecConfig;
 
-// console.log(`${pubDomain}/${shortName}`);
-// TODO: remove voordat we mergen
-console.log(`api/adr`);
+console.log(`${pubDomain}/${shortName}`);

--- a/scripts/compute-published-url.js
+++ b/scripts/compute-published-url.js
@@ -1,4 +1,6 @@
 require("./js/config.js");
 const {pubDomain, shortName} = globalThis.respecConfig;
 
-console.log(`${pubDomain}/${shortName}`);
+// console.log(`${pubDomain}/${shortName}`);
+// TODO: remove voordat we mergen
+console.log(`api/adr`);

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -13,9 +13,7 @@ errors = 0
 content = ''
 
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
-    input_string = input_file.read()
-    print(f"Dit is de string: {input_string}En hier eindigt hij")
-    data = json.loads(input_string.strip())
+    data = json.loads(input_file.read().rstrip())
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/", page['url']):

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -14,11 +14,11 @@ content = ''
 
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
     input_string = input_file.read()
-    print(input_string)
+    print(f"Dit is de string: {input_string}En hier eindigt hij")
     data = json.loads(input_string)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
-        if re.search("publicatie\/[^\/]+\/[^\/]+\/$", page['url']):
+        if re.search("publicatie\/", page['url']):
             content += '\n### ' + page['url'] + '\n'
             page['links'] = sorted(page['links'], key=lambda k: k['url'])
             for link in page['links']:

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -15,7 +15,6 @@ content = ''
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
     # De output van het Node scriptje heeft ook een print regel, dus pak alleen de json
     json_string = input_file.readlines()[1]
-    print(f"Begin{json_string}Einde")
     data = json.loads(json_string)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -6,7 +6,7 @@ import sys
 
 JSON_PATH = 'muffet.json'
 
-if not os.path.exists(JSON_PATH):
+if not os.path.exists(JSON_PATH) or os.path.getsize(JSON_PATH) == 0:
     sys.exit(0)
 
 errors = 0

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -13,8 +13,9 @@ errors = 0
 content = ''
 
 with open(JSON_PATH, 'r') as input_file:
-    print(input_file.read())
-    data = json.loads(input_file.read())
+    input_string = input_file.read()
+    print(input_string)
+    data = json.loads(input_string)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/[^\/]+\/[^\/]+\/$", page['url']):

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -12,7 +12,7 @@ if not os.path.exists(JSON_PATH) or os.path.getsize(JSON_PATH) == 0:
 errors = 0
 content = ''
 
-with open(JSON_PATH, 'r') as input_file:
+with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
     input_string = input_file.read()
     print(input_string)
     data = json.loads(input_string)

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -13,7 +13,9 @@ errors = 0
 content = ''
 
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
-    data = json.loads(input_file.read().rstrip())
+    trimmed_json = input_file.read().rstrip()
+    print(f"Begin{trimed_json}Einde")
+    data = json.loads(trimmed_json)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/", page['url']):

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -15,7 +15,7 @@ content = ''
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
     input_string = input_file.read()
     print(f"Dit is de string: {input_string}En hier eindigt hij")
-    data = json.loads(input_string)
+    data = json.loads(input_string.strip())
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/", page['url']):

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -14,7 +14,7 @@ content = ''
 
 with open(JSON_PATH) as file:
     print(file.read())
-    data = json.load(file)
+    data = json.loads(file.read())
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/[^\/]+\/[^\/]+\/$", page['url']):

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -12,9 +12,9 @@ if not os.path.exists(JSON_PATH) or os.path.getsize(JSON_PATH) == 0:
 errors = 0
 content = ''
 
-with open(JSON_PATH) as file:
-    print(file.read())
-    data = json.loads(file.read())
+with open(JSON_PATH, 'r') as input_file:
+    print(input_file.read())
+    data = json.loads(input_file.read())
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/[^\/]+\/[^\/]+\/$", page['url']):
@@ -24,7 +24,6 @@ with open(JSON_PATH) as file:
                 errors += 1
                 content += '* ' + link['url'] + ' `' + link['error'] + '`' + '\n'
 
-f = open('links.md', 'w')
-f.write('## ' + str(errors) + ' broken links\n')
-f.write(content)
-f.close()
+with open('links.md', 'w') as output_file:
+    output_file.write('## ' + str(errors) + ' broken links\n')
+    output_file.write(content)

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -14,7 +14,7 @@ content = ''
 
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
     trimmed_json = input_file.read().rstrip()
-    print(f"Begin{trimed_json}Einde")
+    print(f"Begin{trimmed_json}Einde")
     data = json.loads(trimmed_json)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -1,11 +1,18 @@
 import json
+import os
 import re
 import requests
+import sys
+
+JSON_PATH = 'muffet.json'
+
+if not os.path.exists(JSON_PATH):
+    sys.exit(0)
 
 errors = 0
 content = ''
 
-with open('muffet.json') as file:
+with open(JSON_PATH) as file:
     data = json.load(file)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -13,9 +13,10 @@ errors = 0
 content = ''
 
 with open(JSON_PATH, 'r',  encoding='utf-8') as input_file:
-    trimmed_json = input_file.read().rstrip()
-    print(f"Begin{trimmed_json}Einde")
-    data = json.loads(trimmed_json)
+    # De output van het Node scriptje heeft ook een print regel, dus pak alleen de json
+    json_string = input_file.readlines()[1]
+    print(f"Begin{json_string}Einde")
+    data = json.loads(json_string)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:
         if re.search("publicatie\/", page['url']):

--- a/scripts/muffet-json.py
+++ b/scripts/muffet-json.py
@@ -13,6 +13,7 @@ errors = 0
 content = ''
 
 with open(JSON_PATH) as file:
+    print(file.read())
     data = json.load(file)
     data = sorted(data, key=lambda k: k['url'])
     for page in data:

--- a/scripts/run-muffet.sh
+++ b/scripts/run-muffet.sh
@@ -13,4 +13,4 @@ muffet \
     --one-page-only \
     --buffer-size 8192 \
     $URL_TO_CHECK \
-    > muffet.json
+    > muffet.json || true

--- a/scripts/run-muffet.sh
+++ b/scripts/run-muffet.sh
@@ -13,5 +13,4 @@ muffet \
     --one-page-only \
     --format=json \
     --buffer-size 8192 \
-    $URL_TO_CHECK \
-    > muffet.json
+    $URL_TO_CHECK

--- a/scripts/run-muffet.sh
+++ b/scripts/run-muffet.sh
@@ -11,6 +11,7 @@ muffet \
     --header 'user-agent:Curl' \
     --ignore-fragments \
     --one-page-only \
+    --format=json \
     --buffer-size 8192 \
     $URL_TO_CHECK \
-    > muffet.json || true
+    > muffet.json

--- a/scripts/run-muffet.sh
+++ b/scripts/run-muffet.sh
@@ -1,0 +1,16 @@
+URL_TO_CHECK="$1"
+
+echo "Checking $URL_TO_CHECK"
+
+muffet \
+    --exclude '8080\/\S*\.pdf' \
+    --exclude 'upwork.com' \
+    --exclude 'sitearchief.nl' \
+    --exclude 'opengis.net' \
+    --exclude 'https://www.nen.nl/nen-7513-2024-nl-329182' \
+    --header 'user-agent:Curl' \
+    --ignore-fragments \
+    --one-page-only \
+    --buffer-size 8192 \
+    $URL_TO_CHECK \
+    > muffet.json


### PR DESCRIPTION
Hiermee hebben we een nieuw workflow bestand die periodiek kan draaien. Een repository kan dan deze includen en hiermee checken of de links van de gepubliceerde versie nog draait. Voor niet- gepubliceerde documenten kan dit nog niet draaien.

Om duplicatie te voorkomen is er ook nu 1 scriptje om `muffet` te draaien.

Dit is alles een vervanging van de vorige link checker die regelmatig tegen rate limiting aan liep. Nu we het per repository draaien lopen we daar hopelijk niet tegen aan.