### PR TITLE
Gebruik published version bij het checken van links

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -13,6 +13,7 @@ jobs:
     if: ${{ github.repository_owner == 'Logius-standaarden' && github.repository != 'Logius-standaarden/ReSpec-template' }}
     steps:
       - uses: actions/checkout@v4
+        ref: main
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install muffet

--- a/scripts/compute-published-url.js
+++ b/scripts/compute-published-url.js
@@ -1,4 +1,4 @@
 require("./js/config.js");
-const {pubDomain, shortName} = globalThis.respecConfig;
+const {pubDomain, shortName, publishVersion} = globalThis.respecConfig;
 
-console.log(`${pubDomain}/${shortName}`);
+console.log(`${pubDomain}/${shortName}/${publishVersion}`);


### PR DESCRIPTION
Run het daarom op `main` om de laatste gepubliceerde
versie te hebben in plaats van de werkversie.