### PR TITLE
Verwijder preview branches

### DIFF
--- a/scripts/cleanup-branches.py
+++ b/scripts/cleanup-branches.py
@@ -1,16 +1,14 @@
 import os
+import shutil
+from pathlib import Path
 from github import Github
 
 g = Github(os.environ['BEHEER'])
 org = g.get_organization('Logius-standaarden')
-preview_repository = org.get_repo('Publicatie-Preview')
+PREVIEW_DIRECTORY = Path(os.getcwd())
 
-def is_preview_branch(path):
-    try:
-        preview_repository.get_contents(f"{path}/index.html")
-        return True
-    except:
-        return False
+def is_preview_branch(directory):
+    return os.path.exists(os.path.join(directory, "index.html"))
 
 def get_repository_branches(repository_name):
     try:
@@ -20,21 +18,19 @@ def get_repository_branches(repository_name):
         print(f"Repository {repository_name} bestaat niet meer en kan geheel worden gedelete")
         return []
 
-all_directories = preview_repository.get_contents("")
-for directory in all_directories:
-    if directory.type == "file":
-        continue
-    
-    repository_name = directory.path
-
+all_directories = [f.name for f in os.scandir(PREVIEW_DIRECTORY) if f.is_dir() ]
+for repository_name in all_directories:
     print(f"Checken van preview branches voor {repository_name}")
 
     # Filter nested directories
     # TODO: Verzin een manier om alsnog recursief te kunnen deleten
-    preview_branches = [preview_branch.name for preview_branch in preview_repository.get_contents(repository_name) if is_preview_branch(preview_branch.path)]
+    preview_branches = [preview_branch.name for preview_branch in os.scandir(PREVIEW_DIRECTORY / repository_name) if is_preview_branch(preview_branch.path)]
 
     repository_branches = get_repository_branches(repository_name)
+
+    print(f"De volgende branches bestaan: {repository_branches}")
 
     for preview_branch in preview_branches:
         if preview_branch not in repository_branches:
             print(f"Kunnen we deleten: {repository_name}/{preview_branch}")
+            shutil.rmtree(os.path.join(PREVIEW_DIRECTORY, repository_name, preview_branch))


### PR DESCRIPTION
Hiermee implementeren het daadwerkelijk verwijderen van de folders. Tevens is het nu een stuk sneller, omdat we het lokale filesysteem kunnen gebruiken voor de file traversal. Dat is omdat we dit scriptje runnen in de preview repository zelf na een checkout.

Fixes #40 