### PR TITLE
Update filenaam van config

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -18,7 +18,7 @@ def getValue(var, line):
     return val
 
 
-config = f"js/config.js"
+config = f"js/config.mjs"
 with open(config, "r", encoding="utf-8") as f:
     pubDomain = ""
     shortName = ""


### PR DESCRIPTION
Dit betekent dat documenten die we nu releasen de
`js/config.mjs` setup moeten gebruiken ipv `js/config.js`