### PR TITLE
Check `config.mjs` om PDF's te genereren

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
          if grep -q alternateFormats ./js/config.js; then
          echo "grep=true" >> $GITHUB_OUTPUT
          fi
+         if grep -q alternateFormats ./js/config.mjs; then
+         echo "grep=true" >> $GITHUB_OUTPUT
+         fi
       - name: PDF
         if: ${{ steps.config.outputs.grep == 'true' }}
         run: |


### PR DESCRIPTION
We gebruiken de nieuwe `config.mjs` setup, maar dat breekt het genereren van PDF's. Dat komt omdat we enkel de oude `config.js` checkten, maar daarnaast dus ook `config.mjs`.

Zodra alle `config.js` zijn opgeruimd kunnen we het eerste if-statement weer weghalen.

Part of Logius-standaarden/Automatisering#51
Fixes Logius-standaarden/logboek-dataverwerkingen#207