### PR TITLE
Revert "Check `config.mjs` om PDF's te genereren"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ jobs:
          if grep -q alternateFormats ./js/config.js; then
          echo "grep=true" >> $GITHUB_OUTPUT
          fi
-         if grep -q alternateFormats ./js/config.mjs; then
-         echo "grep=true" >> $GITHUB_OUTPUT
-         fi
       - name: PDF
         if: ${{ steps.config.outputs.grep == 'true' }}
         run: |


### PR DESCRIPTION
Dit breekt het bouwen van standaarden die `js/config.mjs` hebben,
omdat de scriptjes er vanuit gaan dat `js/config.js` bestaat.
Tevens breekt het ook het inlezen van het bestandje, omdat
we het config object niet exporteren.

Reverts Logius-standaarden/Automatisering#56