### PR TITLE
Accepteer alle links naar NEN

### DIFF
--- a/scripts/run-muffet.sh
+++ b/scripts/run-muffet.sh
@@ -8,7 +8,7 @@ muffet \
     --exclude 'sitearchief.nl' \
     --exclude 'opengis.net' \
     --exclude 'https://creativecommons.org/licenses/by/4.0/legalcode' \
-    --exclude 'https://www.nen.nl/nen-7513-2024-nl-329182' \
+    --exclude 'https://www.nen.nl/' \
     --exclude 'http://iso6523.info/' \
     --header 'user-agent:Curl' \
     --ignore-fragments \


### PR DESCRIPTION
In https://github.com/Logius-standaarden/BOMOS-Fundament/pull/25 timet ook https://www.nen.nl/nen-7522-2021-nl-283706 uit. Laten we ze allemaal negeren, in plaats van de job te laten falen.