### PR TITLE
Genereer preview URL op basis van target branch

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -21,8 +21,8 @@ jobs:
         run: brew install muffet
       - name: Check published documents
         run: |
-          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.js
-          PUBLISHED_DOMAIN=$(node compute-published-url.js)
+          wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
+          PUBLISHED_DOMAIN=$(node compute-published-url.mjs)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/run-muffet.sh
           bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN > muffet.json || true
       - name: Collect broken links

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -24,7 +24,7 @@ jobs:
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
           PUBLISHED_DOMAIN=$(node compute-published-url.mjs)
           wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/run-muffet.sh
-          bash run-muffet.sh https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN > muffet.json || true
+          bash run-muffet.sh $PUBLISHED_DOMAIN > muffet.json || true
       - name: Collect broken links
         id: collect-broken-links
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           if ${{ github.base_ref == 'develop' }}; then
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
           elif ${{ github.base_ref == 'main' }}; then
-            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/baseline-url-diff/scripts/compute-published-url.mjs
+            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
             PUBLISHED_DOMAIN=$(node compute-published-url.mjs)
             echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,12 +111,12 @@ jobs:
           elif ${{ github.base_ref == 'main' || github.base_ref == 'master' }}; then
             wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
             PUBLISHED_DOMAIN=$(node compute-published-url.mjs --previous-url)
-            echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
+            echo "BASELINE_URL_DIFF=$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
           else
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ github.event.repository.name }}/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Post preview link
-        if: steps.findcomment.outputs.comment-id == ''
+        if: steps.findcomment.outputs.comment-id == '' && steps.baseline-url-diff.outputs.BASELINE_URL_DIFF != ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BASELINE_URL_DIFF: ${{ steps.baseline-url-diff.outputs.BASELINE_URL_DIFF }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,13 @@ jobs:
       - name: Kies baseline URL voor diff
         id: baseline-url-diff
         run: |
-          echo "BASELINE_URL_DIFF=\"${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}\"" >> "$GITHUB_OUTPUT"
+          if ${{ github.base_ref == 'develop' }}; then
+            echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
+          elif ${{ github.base_ref == 'main' }}; then
+            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.js
+            PUBLISHED_DOMAIN=$(node compute-published-url.js)
+            echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
+          fi
       - name: Post preview link
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})${{ env.BASELINE_URL_DIFF == '' && '' || format('<br>[Diff met W3CDiff](https://services.w3.org/htmldiff?doc1={0}&doc2={1})', env.BASELINE_URL_DIFF, env.PREVIEW_LINK_URL)}}
+            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})${{ env.BASELINE_URL_DIFF != '' && format('<br>[Diff met W3CDiff](https://services.w3.org/htmldiff?doc1={0}&doc2={1})', env.BASELINE_URL_DIFF, env.PREVIEW_LINK_URL) || '' }}
   consultatie:
     name: Publiceer consultatie
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && ( github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'en' ) }}
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.event.repository.name != 'automatisering-test' && ( github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'en' ) }}
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -103,17 +103,21 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Preview link voor pull request
-
+      - name: Kies baseline URL voor diff
+        id: baseline-url-diff
+        run: |
+          echo "BASELINE_URL_DIFF=\"${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}\"" >> "$GITHUB_OUTPUT"
       - name: Post preview link
         if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
+          BASELINE_URL_DIFF: ${{ steps.baseline-url-diff.outputs.BASELINE_URL_DIFF }}
           PREVIEW_LINK_URL: ${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ env.REPOSITORY_NAME_AND_BRANCH }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})
-            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}&doc2=${{ env.PREVIEW_LINK_URL }})
+            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=${{ env.BASELINE_URL_DIFF }}&doc2=${{ env.PREVIEW_LINK_URL }})
   consultatie:
     name: Publiceer consultatie
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,12 +108,12 @@ jobs:
         run: |
           if ${{ github.base_ref == 'develop' }}; then
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
-          elif ${{ github.base_ref == 'main' || github.base_ref == 'main' }}; then
+          elif ${{ github.base_ref == 'main' || github.base_ref == 'master' }}; then
             wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
             PUBLISHED_DOMAIN=$(node compute-published-url.mjs --previous-url)
             echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
           else
-            echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ github.event.repository.name }}/${{ github.base_ref }}
+            echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ github.event.repository.name }}/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Post preview link
         if: steps.findcomment.outputs.comment-id == ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
             echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
           fi
       - name: Post preview link
-        if: steps.findcomment.outputs.comment-id == ''
+        if: steps.findcomment.outputs.comment-id == '' && steps.baseline-url-diff.outputs.BASELINE_URL_DIFF != ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BASELINE_URL_DIFF: ${{ steps.baseline-url-diff.outputs.BASELINE_URL_DIFF }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,13 +108,15 @@ jobs:
         run: |
           if ${{ github.base_ref == 'develop' }}; then
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
-          elif ${{ github.base_ref == 'main' }}; then
+          elif ${{ github.base_ref == 'main' || github.base_ref == 'main' }}; then
             wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
-            PUBLISHED_DOMAIN=$(node compute-published-url.mjs)
+            PUBLISHED_DOMAIN=$(node compute-published-url.mjs --previous-url)
             echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
+          else
+            echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ github.event.repository.name }}/${{ github.base_ref }}
           fi
       - name: Post preview link
-        if: steps.findcomment.outputs.comment-id == '' && steps.baseline-url-diff.outputs.BASELINE_URL_DIFF != ''
+        if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BASELINE_URL_DIFF: ${{ steps.baseline-url-diff.outputs.BASELINE_URL_DIFF }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})${{ env.BASELINE_URL_DIFF == '' && '' || format('\n[Diff met W3CDiff](https://services.w3.org/htmldiff?doc1={0}&doc2={1})', env.BASELINE_URL_DIFF, env.PREVIEW_LINK_URL)}}
+            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})${{ env.BASELINE_URL_DIFF == '' && '' || format('<br>[Diff met W3CDiff](https://services.w3.org/htmldiff?doc1={0}&doc2={1})', env.BASELINE_URL_DIFF, env.PREVIEW_LINK_URL)}}
   consultatie:
     name: Publiceer consultatie
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,8 +109,8 @@ jobs:
           if ${{ github.base_ref == 'develop' }}; then
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
           elif ${{ github.base_ref == 'main' }}; then
-            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.js
-            PUBLISHED_DOMAIN=$(node compute-published-url.js)
+            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/baseline-url-diff/scripts/compute-published-url.mjs
+            PUBLISHED_DOMAIN=$(node compute-published-url.mjs)
             echo "BASELINE_URL_DIFF=https://gitdocumentatie.logius.nl/publicatie/$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
           fi
       - name: Post preview link

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           if ${{ github.base_ref == 'develop' }}; then
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
           elif ${{ github.base_ref == 'main' || github.base_ref == 'master' }}; then
-            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/main/scripts/compute-published-url.mjs
+            wget https://raw.githubusercontent.com/Logius-standaarden/Automatisering/baseline-url-diff/scripts/compute-published-url.mjs
             PUBLISHED_DOMAIN=$(node compute-published-url.mjs --previous-url)
             echo "BASELINE_URL_DIFF=$PUBLISHED_DOMAIN" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,7 @@ jobs:
             echo "BASELINE_URL_DIFF=${{ env.ORGANISATION_URL }}/${{ env.PREVIEW_REPOSITORY_NAME }}/${{ github.event.repository.name }}/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
           fi
       - name: Post preview link
-        if: steps.findcomment.outputs.comment-id == '' && steps.baseline-url-diff.outputs.BASELINE_URL_DIFF != ''
+        if: steps.findcomment.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v4
         env:
           BASELINE_URL_DIFF: ${{ steps.baseline-url-diff.outputs.BASELINE_URL_DIFF }}
@@ -124,8 +124,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})
-            [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=${{ env.BASELINE_URL_DIFF }}&doc2=${{ env.PREVIEW_LINK_URL }})
+            [Preview link voor pull request](${{ env.PREVIEW_LINK_URL }})${{ env.BASELINE_URL_DIFF == '' && '' || format('\n[Diff met W3CDiff](https://services.w3.org/htmldiff?doc1={0}&doc2={1})', env.BASELINE_URL_DIFF, env.PREVIEW_LINK_URL)}}
   consultatie:
     name: Publiceer consultatie
     runs-on: ubuntu-22.04

--- a/scripts/compute-published-url.js
+++ b/scripts/compute-published-url.js
@@ -1,4 +1,0 @@
-require("./js/config.js");
-const {pubDomain, shortName, publishVersion} = globalThis.respecConfig;
-
-console.log(`${pubDomain}/${shortName}/${publishVersion}`);

--- a/scripts/compute-published-url.mjs
+++ b/scripts/compute-published-url.mjs
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import { exit } from 'node:process';
+
+try {
+  const data = fs.readFileSync('./js/config.mjs', 'utf8');
+  const pubDomain = configText.match(/pubDomain['"]?:\s*['"](?<domain>[^'"]+)/).groups.domain;
+  const shortName = configText.match(/shortName['"]?:\s*['"](?<shortname>[^'"]+)/).groups.shortname;
+  const publishVersion = configText.match(/publishVersion['"]?:\s*['"](?<publishversion>[^'"]+)/).groups.publishversion;
+  console.log(`${pubDomain}/${shortName}/${publishVersion}`);
+} catch (err) {
+  console.error(err);
+  exit(1);
+}

--- a/scripts/compute-published-url.mjs
+++ b/scripts/compute-published-url.mjs
@@ -6,9 +6,18 @@ try {
 
   const pubDomain = configText.match(/pubDomain['"]?:\s*['"](?<domain>[^'"]+)/).groups.domain;
   const shortName = configText.match(/shortName['"]?:\s*['"](?<shortname>[^'"]+)/).groups.shortname;
-  const publishVersion = configText.match(/publishVersion['"]?:\s*['"](?<publishversion>[^'"]+)/).groups.publishversion;
 
-  console.log(`${pubDomain}/${shortName}/${publishVersion}`);
+  if (process.argv.includes("--previous-url")) {
+    const previousPublishVersion = configText.match(/previousPublishVersion['"]?:\s*['"](?<previouspublishversion>[^'"]+)/)?.groups.previouspublishversion;
+
+    if (previousPublishVersion) {
+      console.log(`https://gitdocumentatie.logius.nl/publicatie/${pubDomain}/${shortName}/${previousPublishVersion}`);
+    }
+  } else {
+    const publishVersion = configText.match(/publishVersion['"]?:\s*['"](?<publishversion>[^'"]+)/).groups.publishversion;
+
+    console.log(`https://gitdocumentatie.logius.nl/publicatie/${pubDomain}/${shortName}/${publishVersion}`);
+  }
 } catch (err) {
   console.error(err);
   exit(1);

--- a/scripts/compute-published-url.mjs
+++ b/scripts/compute-published-url.mjs
@@ -2,10 +2,12 @@ import fs from 'node:fs';
 import { exit } from 'node:process';
 
 try {
-  const data = fs.readFileSync('./js/config.mjs', 'utf8');
+  const configText = fs.readFileSync('./js/config.mjs', 'utf8');
+
   const pubDomain = configText.match(/pubDomain['"]?:\s*['"](?<domain>[^'"]+)/).groups.domain;
   const shortName = configText.match(/shortName['"]?:\s*['"](?<shortname>[^'"]+)/).groups.shortname;
   const publishVersion = configText.match(/publishVersion['"]?:\s*['"](?<publishversion>[^'"]+)/).groups.publishversion;
+
   console.log(`${pubDomain}/${shortName}/${publishVersion}`);
 } catch (err) {
   console.error(err);


### PR DESCRIPTION
Voor develop is dat de werkversie. Voor main is dat de gepubliceerde
versie. Hiervoor moest ook `compute-published-url.mjs` worden
geupdatet zodat die om kan gaan met een `.mjs`. Het laat het
bestandje in als tekst, wat niet ideaal is, maar het werkt wel.

Fixes #94