### PR TITLE
Upgrade Ubuntu image voor node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Snapshot
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         source_input_file_name: ${{ fromJSON(inputs.workflow_input_file_names) }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
 jobs:  
   wcag:
     name: WCAG
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
       - name: Recover HTML
@@ -36,7 +36,7 @@ jobs:
   
   markdownlint:
     name: Markdownlint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
       - name: Install markdownlint
@@ -88,7 +88,7 @@ jobs:
           bash run-muffet.sh http://localhost:8080/index.html
   spellchecker:
     name: Run spellcheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
       - name: Install hunspell

--- a/.github/workflows/label-updates.yml
+++ b/.github/workflows/label-updates.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-labels:
     name: "Update labels"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   link-checker:
     name: Check published links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: ${{ github.repository_owner == 'Logius-standaarden' && github.repository != 'Logius-standaarden/ReSpec-template' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && ( github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'en' ) }}
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
          git push
   upload_develop_artifacts:
     name: Upload develop artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: ${{ github.event_name == 'push' && github.repository_owner == 'Logius-standaarden' && github.ref_name == 'develop' }}
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.upload_pages_artifact.outputs.page_url }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     needs: upload_develop_artifacts
     steps:
       - name: Deploy to GitHub Pages
@@ -67,7 +67,7 @@ jobs:
         uses: actions/deploy-pages@v4
   preview:
     name: Preview
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'Logius-standaarden' && github.head_ref != 'develop' }}
     env:
       ORGANISATION_URL: https://logius-standaarden.github.io
@@ -116,7 +116,7 @@ jobs:
             [Diff met W3CDiff](https://services.w3.org/htmldiff?doc1=${{ env.ORGANISATION_URL }}/${{ github.event.repository.name }}&doc2=${{ env.PREVIEW_LINK_URL }})
   consultatie:
     name: Publiceer consultatie
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: ${{ !github.event.pull_request.head.repo.fork && !github.event.pull_request.draft && (startsWith(github.head_ref, 'consultatie/') || startsWith(github.ref_name, 'consultatie/')) }}
     env:
       CONSULTATIE_REPOSITORY_NAME: Openbare-Consultaties


### PR DESCRIPTION
New Ubuntu, new challenge:
`No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.`
Uit https://github.com/Logius-standaarden/OAuth-NL-profiel/pull/139