### PR TITLE
Gebruik Node 24 voor laatste versie van Respec CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           sed -i "$REPLACEMENT_REGEX" js/config.mjs
       - name: Static HTML
         run: |
-          npx respec --localhost --src ${{ matrix.source_input_file_name }} --out ~/static/${{ matrix.source_input_file_name }} --haltonwarn
+          npx respec@37.2.0 --localhost --src ${{ matrix.source_input_file_name }} --out ~/static/${{ matrix.source_input_file_name }} --haltonwarn
       - name: PDF
         run: |
          cp ~/static/${{ matrix.source_input_file_name }} ${{ matrix.source_input_file_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           sed -i "$REPLACEMENT_REGEX" js/config.mjs
       - name: Static HTML
         run: |
-          npx respec@37.2.0 --localhost --src ${{ matrix.source_input_file_name }} --out ~/static/${{ matrix.source_input_file_name }} --haltonwarn
+          npx respec --localhost --src ${{ matrix.source_input_file_name }} --out ~/static/${{ matrix.source_input_file_name }} --haltonwarn
       - name: PDF
         run: |
          cp ~/static/${{ matrix.source_input_file_name }} ${{ matrix.source_input_file_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - run: mkdir ~/static
       - uses: actions/checkout@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
       - name: Check correcte branch
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -91,6 +91,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
       - name: Install hunspell
         run: |
           sudo apt-get install hunspell

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -107,7 +107,7 @@ jobs:
           REPLACEMENT_REGEX="s/spellcheck: false/spellcheck: true/"
           sed -i "$REPLACEMENT_REGEX" js/config.mjs
           mkdir ~/static
-          npx respec@37.2.0 --localhost --src index.html --out ~/static/index.html --haltonwarn
+          npx respec --localhost --src index.html --out ~/static/index.html --haltonwarn
       - name: Run spellcheck
         if: ${{ hashFiles('standaard.dic') != '' }}
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -103,7 +103,7 @@ jobs:
           REPLACEMENT_REGEX="s/spellcheck: false/spellcheck: true/"
           sed -i "$REPLACEMENT_REGEX" js/config.mjs
           mkdir ~/static
-          npx respec --localhost --src index.html --out ~/static/index.html --haltonwarn
+          npx respec@37.2.0 --localhost --src index.html --out ~/static/index.html --haltonwarn
       - name: Run spellcheck
         if: ${{ hashFiles('standaard.dic') != '' }}
         run: |


### PR DESCRIPTION
Dit zorgt ervoor dat we de juiste versie van de CLI gebruiken in combinatie met de versie van Respec die we inladen in de browser.